### PR TITLE
Generate original size in storage-temp path so it can be optimized

### DIFF
--- a/classes/DomManipulator.php
+++ b/classes/DomManipulator.php
@@ -89,6 +89,7 @@ class DomManipulator
             $this->setSrcSetAttribute($node, $sourceSet);
             $this->setSizesAttribute($node, $sourceSet);
             $this->setClassAttribute($node);
+            $this->setSrcAttribute($node, $sourceSet);
 
             return $node->ownerDocument->saveHTML($node);
         };

--- a/classes/ResponsiveImage.php
+++ b/classes/ResponsiveImage.php
@@ -105,6 +105,7 @@ class ResponsiveImage
 
         $this->sourceSet = new SourceSet($this->path, $this->getWidth());
 
+        $this->dimensions[] = $this->getWidth();
         $this->createCopies();
     }
 


### PR DESCRIPTION
I made a change so that the original size will be a dimension in the temp storage folder too. I run imagemin (e.g. mozjpeg etc) scripts on the temp folder so all images are extremely optimized. I do not want to run this over the original media paths, to preserve original data. Because the src and biggest srcset was the original path, these were not optimized images by cli tools, thus bad pagespeed score. 

Hope you find this useful!

