### PR TITLE
Fixed invalid image resource exception on second resize

### DIFF
--- a/classes/ResponsiveImage.php
+++ b/classes/ResponsiveImage.php
@@ -150,8 +150,6 @@ class ResponsiveImage
             return false;
         }
 
-        $this->resizer = new ImageResizer($this->path);
-
         foreach ($this->getUnavailableSizes() as $size) {
             $this->createCopy($size);
         }
@@ -164,6 +162,8 @@ class ResponsiveImage
      */
     protected function createCopy($size)
     {
+        $this->resizer = new ImageResizer($this->path);
+
         // Only scale the image down
         if ($this->resizer->getWidth() < $size) {
             $this->sourceSet->remove($size);


### PR DESCRIPTION
Only 1 file was resized on a page load for me. On the second call I got the error:

```
imagesx(): supplied resource is not a valid Image resource
/mnt/raiddata/www/public/octobercms/htdocs/vendor/october/rain/src/Database/Attach/Resizer.php line 227
```

This might be a October or specific PHP (gd) bug. I init a new `ImageResizer` object for every resize. That way it is fixed. So see for yourself whether you find the need for this fix.
