### PR TITLE
Fixed performance when not using persisting cache

### DIFF
--- a/classes/ResponsiveImage.php
+++ b/classes/ResponsiveImage.php
@@ -162,16 +162,15 @@ class ResponsiveImage
      */
     protected function createCopy($size)
     {
-        $this->resizer = new ImageResizer($this->path);
-
         // Only scale the image down
-        if ($this->resizer->getWidth() < $size) {
+        if ($this->getWidth() < $size) {
             $this->sourceSet->remove($size);
 
             return;
         }
 
         try {
+            $this->resizer = new ImageResizer($this->path);
             $this->resizer->resize($size, null)->save($this->getStoragePath($size));
         } catch (\Exception $e) {
             // Cannot resize image to this size. Remove it from the srcset.


### PR DESCRIPTION
This fixes the performance issues when using array cache (thus no cache). Addition on previous pull request: https://github.com/OFFLINE-GmbH/oc-responsive-images-plugin/pull/37

800ms faster loading times on slow machines.