### PR TITLE
Enable to set APP_DIR in env

### DIFF
--- a/webp.php
+++ b/webp.php
@@ -26,7 +26,8 @@ function main()
         $source = '/' . $source;
     }
 
-    $source      = __DIR__ . '/../../..' . $source;
+    //Enable to set a APP_DIR via SetEnv in .htaccess and check tha path with realpath
+    $source      = realpath(env('APP_DIR', __DIR__ . '/../../..')) . $source;
     $destination = $source . '.webp';
 
     $path = validatePath($source);
@@ -80,7 +81,8 @@ function validatePath(string $path)
         return '';
     }
 
-    $path = realpath($path);
+    //$path = realpath($path); causing path mismatch in some environment
+    //Just check that path, not override it.
     if ( ! realpath($path)) {
         return '';
     }


### PR DESCRIPTION
Enable to set APP_DIR in env as current `$source` in webp.php not working in some environment like updating document root symbolic link to latest release with CI / CD.

If no APP_DIR is provided, ordinary `__DIR__ . '/../../..'` will be used.

If you need to set APP_DIR, you may need to set SetEnv in .htaccess like so:

```
# set APP_DIR for oc-responsive-images-plugin
SetEnv APP_DIR /some/unique/app-dir
```

