### PR TITLE
Fix PHP implode deprecation warning on log

### DIFF
--- a/classes/SourceSet.php
+++ b/classes/SourceSet.php
@@ -103,7 +103,7 @@ class SourceSet
             $attribute[] = sprintf('%s ' . $sizePlaceholder, $paths['public_url'], $size);
         }
 
-        return implode($attribute, ', ');
+        return implode(', ', $attribute);
     }
 
     /**


### PR DESCRIPTION
See more: https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.implode-reverse-parameters