### PR TITLE
[FIX] single dropColumn() call

### DIFF
--- a/updates/add_focus_columns_to_system_files.php
+++ b/updates/add_focus_columns_to_system_files.php
@@ -16,8 +16,10 @@ class AddFocusColumnsToSystemFiles extends Migration
     public function down()
     {
         Schema::table('system_files', function ($table) {
-            $table->dropColumn('offline_responsiveimages_focus_x_axis');
-            $table->dropColumn('offline_responsiveimages_focus_y_axis');
+            $table->dropColumn([
+                'offline_responsiveimages_focus_x_axis',
+                'offline_responsiveimages_focus_y_axis'
+            ]);
         });
     }
 }


### PR DESCRIPTION
[...] You may drop multiple columns from a table by passing an array of column names to the dropColumn method [...]

https://laravel.com/docs/6.x/migrations#dropping-columns