### PR TITLE
Using Media\Classes\MediaLibrary

### DIFF
--- a/classes/ResponsiveImage.php
+++ b/classes/ResponsiveImage.php
@@ -10,7 +10,7 @@ use OFFLINE\ResponsiveImages\Classes\Exceptions\FileNotFoundException;
 use OFFLINE\ResponsiveImages\Classes\Exceptions\RemotePathException;
 use OFFLINE\ResponsiveImages\Classes\Exceptions\UnallowedFileTypeException;
 use OFFLINE\ResponsiveImages\Models\Settings;
-use System\Classes\MediaLibrary;
+use Media\Classes\MediaLibrary;
 use URL;
 use WebPConvert\WebPConvert;
 


### PR DESCRIPTION
Should fix the System\Classes\MediaLibrary is deprecated use Media\Classes\MediaLibrary error in event log