### PR TITLE
Added console command and report widget to clear images cache

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -8,6 +8,7 @@ use OFFLINE\ResponsiveImages\Classes\Focuspoint\File as FocusFile;
 use OFFLINE\ResponsiveImages\Classes\SVG\SVGInliner;
 use OFFLINE\ResponsiveImages\Console\ConvertCommand;
 use OFFLINE\ResponsiveImages\Console\GenerateResizedImages;
+use OFFLINE\ResponsiveImages\Console\Clear;
 use System\Classes\PluginBase;
 use System\Models\File;
 use System\Traits\AssetMaker;
@@ -131,6 +132,7 @@ class Plugin extends PluginBase
     {
         $this->registerConsoleCommand('responsiveimages:generate', GenerateResizedImages::class);
         $this->registerConsoleCommand('responsiveimages:convert', ConvertCommand::class);
+        $this->registerConsoleCommand('responsiveimages:clear', Clear::class);
     }
 
     public function registerMarkupTags()
@@ -143,6 +145,21 @@ class Plugin extends PluginBase
                     return (new SVGInliner($themeDir))->inline($path, $vars);
                 },
             ],
+        ];
+    }
+
+    /**
+     * Returns the extra report widgets.
+     * 
+     * @return  array
+     */
+    public function registerReportWidgets()
+    {
+        return [
+            'OFFLINE\ResponsiveImages\ReportWidgets\ClearCache' => [
+                'label'   => 'offline.responsiveimages::lang.reportwidgets.clearcache.label',
+                'context' => 'dashboard'
+            ]
         ];
     }
 

--- a/console/Clear.php
+++ b/console/Clear.php
@@ -1,0 +1,62 @@
+<?php namespace OFFLINE\ResponsiveImages\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+use Artisan;
+use File;
+
+/**
+ * Clear Command
+ */
+class Clear extends Command
+{
+    /**
+     * @var string name is the console command name
+     */
+    protected $name = 'responsive-images:clear';
+
+    /**
+     * @var string description is the console command description
+     */
+    protected $description = 'No description provided yet...';
+
+    /**
+     * handle executes the console command
+     */
+    public function handle()
+    {
+        // Clear cache and thumbnails
+        Artisan::call('cache:clear');
+        Artisan::call('october:util purge thumbs');
+
+        // Clear resized images
+        $path = storage_path('app/resources/resize');
+        File::cleanDirectory($path);
+        
+        // Clear responsive images
+        $path = storage_path('temp/public');
+        $root = new \RecursiveDirectoryIterator($path);
+        $directories = new \RecursiveIteratorIterator($root);
+        foreach ($directories as $directory) {
+            File::delete(File::glob($directory->getPath().'/img_*'));
+        }
+    }
+
+    /**
+     * getArguments get the console command arguments
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
+    /**
+     * getOptions get the console command options
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -78,4 +78,13 @@
         'allow_inline_sizing' => 'Inline-CSS for image width and height',
         'allow_inline_sizing_comment' => 'Inject the width and height CSS rules directly as style attribute into the HTML source',
     ],
+
+    'reportwidgets' => [
+        'clearcache' => [
+            'description' => 'Click the button below to clear all cached images.',
+            'button' => 'Clear image cache',
+            'confirm' => 'Are you sure you want to clear the image cache ?',
+            'success' => 'Image cache successfully cleared',
+        ],
+    ]
 ];

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -42,5 +42,14 @@
 
         'add_class' => 'attribut class',
         'add_class_comment' => 'Ajoutez cette classe à chaque image traitée. Utile si vous utilisez un framework css comme Bootstrap.',
+    ],
+
+    'reportwidgets' => [
+        'clearcache' => [
+            'description' => 'Cliquez sur le bouton ci-dessous pour vider le cache des images.',
+            'button' => 'Vider le cache des images',
+            'confirm' => 'Êtes-vous sur de vouloir vider le cache des images ?',
+            'success' => 'Cache des images vidé avec succès',
+        ],
     ]
 ];

--- a/reportwidgets/ClearCache.php
+++ b/reportwidgets/ClearCache.php
@@ -1,0 +1,63 @@
+<?php namespace OFFLINE\ResponsiveImages\ReportWidgets;
+
+use Backend\Classes\ReportWidgetBase;
+use Exception;
+
+use Artisan;
+use Flash;
+use Lang;
+
+/**
+ * ClearCache Report Widget
+ */
+class ClearCache extends ReportWidgetBase
+{
+    /**
+     * @inheritDoc
+     */
+    protected $defaultAlias = 'ClearCacheReportWidget';
+
+    /**
+     * defineProperties for the widget
+     */
+    public function defineProperties()
+    {
+        return [
+            'title' => [
+                'title' => 'backend::lang.dashboard.widget_title_label',
+                'default' => 'Clear image cache',
+                'type' => 'string',
+                'validationPattern' => '^.+$',
+                'validationMessage' => 'backend::lang.dashboard.widget_title_error',
+            ],
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render()
+    {
+        try {
+            $this->prepareVars();
+        }
+        catch (Exception $ex) {
+            $this->vars['error'] = $ex->getMessage();
+        }
+
+        return $this->makePartial('clearcache');
+    }
+
+    public function onClearCache() {
+        Artisan::call('responsive-images:clear');
+        Flash::success(Lang::get('offline.responsiveimages::lang.reportwidgets.clearcache.success'));
+    }
+
+    /**
+     * Prepares the report widget view data
+     */
+    public function prepareVars()
+    {
+    }
+
+}

--- a/reportwidgets/clearcache/partials/_clearcache.htm
+++ b/reportwidgets/clearcache/partials/_clearcache.htm
@@ -1,0 +1,16 @@
+<div class="report-widget">
+    <h3><?= e($this->property('title')) ?></h3>
+
+    <?php if (!isset($error)): ?>
+        <p><?= e(trans('offline.responsiveimages::lang.reportwidgets.clearcache.description')) ?></p>
+        <a  
+            data-request="onClearCache"
+            data-request-confirm="<?= e(trans('offline.responsiveimages::lang.reportwidgets.clearcache.confirm')) ?>"
+            data-attach-loading
+            class="btn btn-warning">
+            <?= e(trans('offline.responsiveimages::lang.reportwidgets.clearcache.button')) ?>
+        </a>
+    <?php else: ?>
+        <p class="flash-message static warning"><?= e($error) ?></p>
+    <?php endif ?>
+</div>


### PR DESCRIPTION
This PR provide 2 methods to clear cache of images.
- A new console command : `php artisan responsive-images:clear`
- A new report widget with a button that trigger the above artisan command.

This new command do 2 things to clear images cache : 
- Clean the storage/app/resources/resize folder where image resized by the core Resizer class are located
- Clean all images with prefix "img_" located in storage/temp/public where this plugin stock the responsive images.

This PR fix this issue #64 