### PR TITLE
Fix for passing '--include-since' option

### DIFF
--- a/classes/convert/PathProcessorOptions.php
+++ b/classes/convert/PathProcessorOptions.php
@@ -23,7 +23,7 @@ class PathProcessorOptions
     {
         $this->format = $format;
         $this->size = $size;
-        $this->since = $since ? strtotime($since) : Settings::get('latest_conversion', '0');
+        $this->since = $since ?: Settings::get('latest_conversion', '0');
     }
 
     /**


### PR DESCRIPTION
When the artisan command `php artisan responsive-images:convert` is used with the `--include-since` option we don't need to convert it with `strtotime` since the `Symfony\Component\Finder::date` handles this. 
The current implementation gives errors indicating that an invalid date is specified. This is because the date has already been converted to a time. 
I hope I have explained sufficiently why I am offering this PR.