### PR TITLE
Fix error when using clear cache widget

### DIFF
--- a/console/Clear.php
+++ b/console/Clear.php
@@ -27,7 +27,10 @@ class Clear extends Command
     {
         // Clear cache and thumbnails
         Artisan::call('cache:clear');
-        Artisan::call('october:util', ['name' => 'purge thumbs']);
+        Artisan::call('october:util', [
+            'name' => 'purge thumbs',
+            '--force' => true,
+        ]);
 
         // Clear resized images
         $path = storage_path('app/resources/resize');


### PR DESCRIPTION
Fix error when clearing cache : 

Undefined constant "STDIN"" on line 109 of /vendor/symfony/console/Helper/QuestionHelper.php

It's due to the confirmation prompt. Using --force parameter fix the issue.