### PR TITLE
Update Clear.php

### DIFF
--- a/console/Clear.php
+++ b/console/Clear.php
@@ -5,6 +5,8 @@ use Illuminate\Console\Command;
 use Artisan;
 use File;
 
+use OFFLINE\ResponsiveImages\Models\Settings;
+
 /**
  * Clear Command
  */
@@ -40,8 +42,9 @@ class Clear extends Command
         $path = storage_path('temp/public');
         $root = new \RecursiveDirectoryIterator($path);
         $directories = new \RecursiveIteratorIterator($root);
+        $extensions = Settings::get('allowed_extensions');
         foreach ($directories as $directory) {
-            File::delete(File::glob($directory->getPath().'/thumb_*'));
+            File::delete(File::glob($directory->getPath().'/*.{'.$extensions.'}', GLOB_BRACE));
         }
     }
 


### PR DESCRIPTION
Hello,

I noticed during some tests that the clear image widget don't correctly clear all temporary images.

It was because the commande looked at images prefixed with thumb_, don't know if it changed recently with the latest version of october, but images generated with responsive images are not prefixed like that.

To provide a more robust solution, this change look at the image extension responsive image parse (by reading settings) and delete all files that have that extension.