### PR TITLE
Add missing trailling slash

### DIFF
--- a/classes/ResponsiveImage.php
+++ b/classes/ResponsiveImage.php
@@ -225,7 +225,7 @@ class ResponsiveImage
      */
     protected function getStoragePath($size)
     {
-        $path = temp_path('public/' . $this->getPartitionDirectory());
+        $path = rtrim(temp_path('public/' . $this->getPartitionDirectory()), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
         if ( ! FileHelper::isDirectory($path)) {
             FileHelper::makeDirectory($path, 0777, true, true);
         }

--- a/console/Clear.php
+++ b/console/Clear.php
@@ -20,7 +20,7 @@ class Clear extends Command
     /**
      * @var string description is the console command description
      */
-    protected $description = 'No description provided yet...';
+    protected $description = 'Clear generated responsive images';
 
     /**
      * handle executes the console command


### PR DESCRIPTION
This PR ensures that the path to the generated images continues through three levels of depth by adding a trailing slash if it is not present.

Fix #103 