### PR TITLE
Make it possible to disable real path check before resizing files

### DIFF
--- a/classes/ResponsiveImage.php
+++ b/classes/ResponsiveImage.php
@@ -94,14 +94,12 @@ class ResponsiveImage
     protected $webPEnabled = false;
 
     /**
-     * Use real path.
-     *
-     * These value is overridden by the plugin's
-     * settings!
+     * Realpath set to true will try to resolve the real path
+     * Setting it to false may be helpful for symlinks installations
      *
      * @var boolean
      */
-    protected $use_real_path = true;
+    protected $useRealPath = true;
 
     /**
      * Create all the needed copies of the image.
@@ -115,7 +113,7 @@ class ResponsiveImage
 
         $this->loadSettings();
 
-        if ( ! FileHelper::isLocalPath($this->path, $this->use_real_path)) {
+        if ( ! FileHelper::isLocalPath($this->path, $this->useRealPath)) {
             throw new RemotePathException(sprintf('The specified path is not local: %s', $imagePath));
         }
 
@@ -325,7 +323,7 @@ class ResponsiveImage
         $this->dimensions = Settings::getCommaSeparated('dimensions', $this->dimensions);
         $this->allowedExtensions = Settings::getCommaSeparated('allowed_extensions', $this->allowedExtensions);
         $this->webPEnabled = (bool)Settings::get('webp_enabled', false);
-        $this->use_real_path = (bool)Settings::get('use_real_path', true);
+        $this->useRealPath = (bool)Settings::get('use_real_path', true);
     }
 
     /**

--- a/classes/ResponsiveImage.php
+++ b/classes/ResponsiveImage.php
@@ -94,6 +94,16 @@ class ResponsiveImage
     protected $webPEnabled = false;
 
     /**
+     * Use real path.
+     *
+     * These value is overridden by the plugin's
+     * settings!
+     *
+     * @var boolean
+     */
+    protected $use_real_path = true;
+
+    /**
      * Create all the needed copies of the image.
      *
      * @param      $imagePath
@@ -103,7 +113,9 @@ class ResponsiveImage
         $imagePath = urldecode($imagePath);
         $this->path = $this->normalizeImagePath($imagePath);
 
-        if ( ! FileHelper::isLocalPath($this->path)) {
+        $this->loadSettings();
+
+        if ( ! FileHelper::isLocalPath($this->path, $this->use_real_path)) {
             throw new RemotePathException(sprintf('The specified path is not local: %s', $imagePath));
         }
 
@@ -111,7 +123,6 @@ class ResponsiveImage
             throw new FileNotFoundException(sprintf('The specified file does not exist: %s', $imagePath));
         }
 
-        $this->loadSettings();
         $this->parseImagePath();
 
         $this->focus = [];
@@ -314,6 +325,7 @@ class ResponsiveImage
         $this->dimensions = Settings::getCommaSeparated('dimensions', $this->dimensions);
         $this->allowedExtensions = Settings::getCommaSeparated('allowed_extensions', $this->allowedExtensions);
         $this->webPEnabled = (bool)Settings::get('webp_enabled', false);
+        $this->use_real_path = (bool)Settings::get('use_real_path', true);
     }
 
     /**

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -34,6 +34,9 @@
         'allowed_extensions' => 'Processed file extensions',
         'allowed_extensions_comment' => 'Comma separated list of file extensions that should be processed',
 
+        'use_real_path' => 'Use real path',
+        'use_real_path_comment' => 'Turning off that setting, may help with setups that are using project-level symlink',
+
         'webp_enabled' => 'Enable WebP support',
         'webp_enabled_comment' => 'Images are automatically served in the WebP format to supported browsers. Please read the README on GitHub before enabling this option!',
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -35,7 +35,7 @@
         'allowed_extensions_comment' => 'Comma separated list of file extensions that should be processed',
 
         'use_real_path' => 'Use real path',
-        'use_real_path_comment' => 'Turning off that setting, may help with setups that are using project-level symlink',
+        'use_real_path_comment' => 'Disabling this may be required if you use symlinks in your installation',
 
         'webp_enabled' => 'Enable WebP support',
         'webp_enabled_comment' => 'Images are automatically served in the WebP format to supported browsers. Please read the README on GitHub before enabling this option!',

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -37,6 +37,7 @@ class Settings extends Model
         $this->alternative_src = 'src, data-src';
         $this->alternative_src_set = 'srcset, data-srcset';
         $this->log_unprocessable = true;
+        $this->use_real_path = true;
     }
 
     public static function getCommaSeparated($key, $default = null)

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -19,6 +19,12 @@ tabs:
             comment: 'offline.responsiveimages::lang.settings.allowed_extensions_comment'
             placeholder: 'jpg,jpeg,png,gif'
             tab: 'Responsive Image'
+        use_real_path:
+            type: switch
+            span: left
+            label: 'offline.responsiveimages::lang.settings.use_real_path'
+            comment: 'offline.responsiveimages::lang.settings.use_real_path_comment'
+            tab: 'Responsive Image'
         webp_section:
             label: 'offline.responsiveimages::lang.settings.sections.webp'
             type: section

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -22,6 +22,7 @@ tabs:
         use_real_path:
             type: switch
             span: left
+            default: true
             label: 'offline.responsiveimages::lang.settings.use_real_path'
             comment: 'offline.responsiveimages::lang.settings.use_real_path_comment'
             tab: 'Responsive Image'

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -35,7 +35,7 @@
 2.2.0: Added support for automatic WebP conversion
 2.2.1: Optimized WebP implementation
 2.2.2: Performance improvements (thanks to @mauserrifle)
-2.2.3: Optimized handling of custom src attributes 
+2.2.3: Optimized handling of custom src attributes
 2.2.4: Optimized PHP 7.4 support
 2.2.5: Further optimized PHP 7.4 support
 2.2.6: Optimized WebP image quality
@@ -120,3 +120,5 @@
     - 'Fixed config extension event handler'
 2.7.4:
     - 'Removed gif as default file extension as it is not supported by cwebp (thanks to @verenaroe)'
+2.8.0:
+    - 'Make it possible to disable real path check before resizing files'


### PR DESCRIPTION
Hi @tobias-kuendig,

As mentioned here: https://github.com/OFFLINE-GmbH/oc-responsive-images-plugin/pull/90 and here: https://github.com/OFFLINE-GmbH/oc-responsive-images-plugin/issues/89

I've cleaned the PR a little to match the standards better. It doesn't seem like a popular thing thus I've set default to true in all cases and all people who don't want it have to disable it manually.

Cheers,

Tomasz